### PR TITLE
Unnecessary verification even when safety checks are disabled

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -409,8 +409,9 @@ class PrefixReplaceLinkAction(LinkPathAction):
         self._verified = True
 
     def execute(self):
-        if not self._verified:
-            self.verify()
+        if not context.safety_checks == SafetyChecks.disabled:
+            if not self._verified:
+                self.verify()
         source_path = self.intermediate_path or self.source_full_path
         log.trace("linking %s => %s", source_path, self.target_full_path)
         create_link(source_path, self.target_full_path, self.link_type)


### PR DESCRIPTION
The code verifies the packages even when safety checks are disabled , this should not be the case I believe. 